### PR TITLE
Display only one checkbox for the Sentinel label

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -35,7 +35,7 @@
 
 					<div class="form-group">
 						<label for="sentinel" class="col-sm-3">Sentinel:</label>
-						<div class="col-sm-9">
+						<div class="col-sm-1">
 							<input id="sentinel" name="sentinel" type="checkbox" class="form-control"/>
 						</div>
 					</div>


### PR DESCRIPTION
Using col-sm-9 results in four checkboxes being displayed.

![four checkboxes](https://user-images.githubusercontent.com/96679/40266537-04c1e0a6-5b45-11e8-9526-f977be17aeb4.png)

Changing this to col-sm-1 produces 1 checkbox aligned next to the Sentinel label.

![one checkbox](https://user-images.githubusercontent.com/96679/40266540-0cc86dba-5b45-11e8-9235-26f62fc6f358.png)
